### PR TITLE
[#14] Use PSR-20 Clock interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         "php": "^7.4|^8.0|^8.1|^8.2",
         "pheature/toggle-core": "^0.7",
         "pheature/toggle-model": "^0.7",
-        "stella-maris/clock": "^0.1.6",
+        "psr/clock": "^1.0",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {
-        "beste/clock": "^2.1",
+        "beste/clock": "^2.1|^3.0",
         "icanhazstring/composer-unused": "^0.8",
         "phpcompatibility/php-compatibility": "^9.3",
         "phpro/grumphp": "^1.0",

--- a/src/IntervalMatchingSegment.php
+++ b/src/IntervalMatchingSegment.php
@@ -3,7 +3,7 @@
 namespace Pheature\Model\DateTime;
 
 use Pheature\Core\Toggle\Read\Segment;
-use StellaMaris\Clock\ClockInterface;
+use Psr\Clock\ClockInterface;
 
 class IntervalMatchingSegment implements Segment
 {

--- a/src/IntervalSegmentFactory.php
+++ b/src/IntervalSegmentFactory.php
@@ -7,7 +7,7 @@ namespace Pheature\Model\DateTime;
 use Pheature\Core\Toggle\Exception\InvalidSegmentTypeGiven;
 use Pheature\Core\Toggle\Read\Segment;
 use Pheature\Core\Toggle\Read\SegmentFactory;
-use StellaMaris\Clock\ClockInterface;
+use Psr\Clock\ClockInterface;
 
 class IntervalSegmentFactory implements SegmentFactory
 {

--- a/src/IntervalSegmentFactoryFactory.php
+++ b/src/IntervalSegmentFactoryFactory.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Pheature\Model\DateTime;
 
 use Pheature\Core\Toggle\Read\SegmentFactory;
+use Psr\Clock\ClockInterface;
 use Psr\Container\ContainerInterface;
-use StellaMaris\Clock\ClockInterface;
 use Webmozart\Assert\Assert;
 
 class IntervalSegmentFactoryFactory

--- a/src/IntervalStrictMatchingSegment.php
+++ b/src/IntervalStrictMatchingSegment.php
@@ -6,7 +6,7 @@ namespace Pheature\Model\DateTime;
 
 use Pheature\Core\Toggle\Read\Segment;
 use Pheature\Model\Toggle\StrictMatchingSegment;
-use StellaMaris\Clock\ClockInterface;
+use Psr\Clock\ClockInterface;
 
 /**
  * @psalm-import-type Criteria from IntervalCriteria

--- a/test/IntervalSegmentFactoryFactoryTest.php
+++ b/test/IntervalSegmentFactoryFactoryTest.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Pheature\Test\Model\DateTime;
 
 use Beste\Clock\SystemClock;
-use Pheature\Core\Toggle\Exception\InvalidSegmentTypeGiven;
 use Pheature\Model\DateTime\IntervalSegmentFactory;
 use Pheature\Model\DateTime\IntervalSegmentFactoryFactory;
-use Pheature\Model\DateTime\IntervalStrictMatchingSegment;
 use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
 use Psr\Container\ContainerInterface;
-use StellaMaris\Clock\ClockInterface;
 
 class IntervalSegmentFactoryFactoryTest extends TestCase
 {


### PR DESCRIPTION
Adds BC Break. We stopped using stella-maris/clock to start using the accepted PSR-20 Clock. Fixes #14.